### PR TITLE
Fixed case of exportType select id

### DIFF
--- a/FlightsOfIdeas/svgExportDialog.html
+++ b/FlightsOfIdeas/svgExportDialog.html
@@ -156,9 +156,9 @@ function setDefaults(defaults)
 		changeUnits();
 	}
 	
-	document.getElementById("exporttype").selectedIndex = 0;
+	document.getElementById("exportType").selectedIndex = 0;
 	if (args[3] == "lines")
-		document.getElementById("exporttype").selectedIndex = 1;	
+		document.getElementById("exportType").selectedIndex = 1;	
 	
 	if (args[4] == "true")
 		document.getElementById("exportHidden").checked = true;	
@@ -259,7 +259,7 @@ function doLoad()
 				<tr>
 					<td width="4.5%"></td>
 					<td width="25%"><p class="heading-green">Group exported face(s) as: </p></td>
-					<td width="25%"><select width="100%" id="exporttype">									
+					<td width="25%"><select width="100%" id="exportType">									
 									<option id="paths">Paths...</option>
 									<option id="lines">Lines...</option>									
 								</select></td>


### PR DESCRIPTION
The inconsistent casing was causing the export to fail and not save the SVG file. I made all consistent with camel-casing. Line 72 was failing before this fix. I'm running SketchUp 2015 so I'm not sure if the problem existed in previous versions as well.
